### PR TITLE
Deprecated subItem command and added a new labeliii override

### DIFF
--- a/resume.tex
+++ b/resume.tex
@@ -92,9 +92,8 @@
     \end{tabular*}\vspace{-7pt}
 }
 
-\newcommand{\resumeSubItem}[1]{\resumeItem{#1}\vspace{-4pt}}
-
 \renewcommand\labelitemii{$\vcenter{\hbox{\tiny$\bullet$}}$}
+\renewcommand\labelitemiii{$\textendash$}
 
 \newcommand{\resumeSubHeadingListStart}{\begin{itemize}[leftmargin=0.15in, label={}]}
 \newcommand{\resumeSubHeadingListEnd}{\end{itemize}}


### PR DESCRIPTION
The old SubItem command was not working correctly. I decided to override LaTex's default sub-bullet which was this ugly asterisk. Now it just adds a dash. Ready for merge ✅ 